### PR TITLE
Harden upload.sh and add bats tests

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -1,0 +1,27 @@
+name: test-and-lint
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: setup-bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          github-token: ${{ github.token }}
+      - name: bats
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
+        run: bats test
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: shellcheck
+        run: shellcheck upload.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Go Lift - Building Strong Go Tools
+Copyright (c) 2022-2026 Go Lift - Building Strong Go Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ All the other similar actions out there have flaws and do not meet my needs.
 This one probably has flaws too, but it tries to be better.
 If you need any other features, please [ask](https://github.com/golift/upload-packagecloud/issues/new).
 
+Pin `uses: golift/upload-packagecloud@v1` (or `@v1.N`). Pushing a `vN.N.N` tag
+moves those floating tags to the new commit when it is the highest matching release.
+
 ## Inputs
 
 - Version 1 has three required inputs: `userrepo`, `apitoken` and `packages`.
@@ -26,18 +29,18 @@ Store your Package Cloud API token in GitHub Secrets and pass it in here.
 This input may be either a folder or a single file name.
 If it's a single file, any package type is supported,
 but you have little control over the "distribution version" for non-RPM/DEB package types.
-If a folder is provided, all `*.deb` and `*.rpm` files in it (non-recusrive) are uploaded.
+If a folder is provided, all `*.deb` and `*.rpm` files in it (non-recursive) are uploaded.
 No other package types are supported for a folder input.
 
 ### rpmdists
 
-This optional field controls which YUM distribtions RPM packages are uploaded to.
+This optional field controls which YUM distributions RPM packages are uploaded to.
 Specify more than 1 by separating them with spaces.
 Examples: `el/6 el/7 ol/6 ol/7`
 
 ### debdists
 
-This optional field controls which APT distribtions DEB packages are uploaded to.
+This optional field controls which APT distributions DEB packages are uploaded to.
 Specify more than 1 by separating them with spaces.
 Examples: `debian/buster ubuntu/focal`
 

--- a/test/upload.bats
+++ b/test/upload.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT="${BATS_TEST_TMPDIR}"
+  BIN="${TEST_ROOT}/bin"
+  mkdir -p "${BIN}"
+  export PACKAGECLOUD_LOG="${TEST_ROOT}/package_cloud.log"
+  export GEM_LOG="${TEST_ROOT}/gem.log"
+  : > "${PACKAGECLOUD_LOG}"
+  : > "${GEM_LOG}"
+
+  cat > "${BIN}/package_cloud" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${PACKAGECLOUD_LOG}"
+EOF
+  cat > "${BIN}/gem" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${GEM_LOG}"
+exit 0
+EOF
+  cat > "${BIN}/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+  chmod +x "${BIN}/package_cloud" "${BIN}/gem" "${BIN}/sudo"
+
+  export PATH="${BIN}:${PATH}"
+  export REPO="golift/pkgs"
+  export PACKAGECLOUD_TOKEN="test-token"
+  export PACKAGECLOUD_RPM_DISTRIB=""
+  export PACKAGECLOUD_DEB_DISTRIB=""
+  SCRIPT="${BATS_TEST_DIRNAME}/../upload.sh"
+}
+
+@test "missing REPO fails" {
+  export REPO=""
+  export SOURCE="${TEST_ROOT}/pkg.deb"
+  touch "${SOURCE}"
+  run "${SCRIPT}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"No REPO provided!"* ]]
+}
+
+@test "missing SOURCE fails" {
+  export SOURCE=""
+  run "${SCRIPT}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"No SOURCE provided!"* ]]
+}
+
+@test "missing token fails" {
+  export PACKAGECLOUD_TOKEN=""
+  export SOURCE="${TEST_ROOT}/pkg.deb"
+  touch "${SOURCE}"
+  run "${SCRIPT}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"No PACKAGECLOUD_TOKEN provided!"* ]]
+}
+
+@test "missing file fails" {
+  export SOURCE="${TEST_ROOT}/no-such.deb"
+  run "${SCRIPT}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"SOURCE is not a file or directory:"* ]]
+}
+
+@test "empty folder fails" {
+  mkdir -p "${TEST_ROOT}/empty"
+  export SOURCE="${TEST_ROOT}/empty"
+  run "${SCRIPT}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"No .deb or .rpm files in ${SOURCE}"* ]]
+}
+
+@test "folder with only debs uploads each deb dist and no rpms" {
+  mkdir -p "${TEST_ROOT}/pkgs"
+  touch "${TEST_ROOT}/pkgs/app.deb"
+  export SOURCE="${TEST_ROOT}/pkgs"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal debian/buster"
+  export PACKAGECLOUD_RPM_DISTRIB="el/6"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/ubuntu/focal ${TEST_ROOT}/pkgs/app.deb
+push golift/pkgs/debian/buster ${TEST_ROOT}/pkgs/app.deb" ]
+}
+
+@test "folder with deb and rpm uploads both types" {
+  mkdir -p "${TEST_ROOT}/pkgs"
+  touch "${TEST_ROOT}/pkgs/app.deb" "${TEST_ROOT}/pkgs/app.rpm"
+  export SOURCE="${TEST_ROOT}/pkgs"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
+  export PACKAGECLOUD_RPM_DISTRIB="el/6"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/ubuntu/focal ${TEST_ROOT}/pkgs/app.deb
+push golift/pkgs/el/6 ${TEST_ROOT}/pkgs/app.rpm" ]
+}
+
+@test "single rpm with two rpmdists uploads twice" {
+  export SOURCE="${TEST_ROOT}/pkg.rpm"
+  touch "${SOURCE}"
+  export PACKAGECLOUD_RPM_DISTRIB="el/6 el/7"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/el/6 ${SOURCE}
+push golift/pkgs/el/7 ${SOURCE}" ]
+}
+
+@test "non-rpm/deb file uploads to repo with no dist suffix" {
+  export SOURCE="${TEST_ROOT}/mod.tgz"
+  touch "${SOURCE}"
+  export PACKAGECLOUD_RPM_DISTRIB="el/6"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs ${SOURCE}" ]
+}
+
+@test "skips gem install when package_cloud is on PATH" {
+  export SOURCE="${TEST_ROOT}/pkg.deb"
+  touch "${SOURCE}"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ ! -s "${GEM_LOG}" ]
+}

--- a/upload.sh
+++ b/upload.sh
@@ -1,60 +1,121 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 shopt -s nullglob
 
-echo "Installing package cloud gem..."
-sudo gem install --no-document package_cloud
+install_cli() {
+  if command -v package_cloud >/dev/null 2>&1; then
+    return
+  fi
 
-echo "REPO=${REPO}"
-echo "SOURCE=${SOURCE}"
-echo "PACKAGECLOUD_RPM_DISTRIB=${PACKAGECLOUD_RPM_DISTRIB}"
-echo "PACKAGECLOUD_DEB_DISTRIB=${PACKAGECLOUD_DEB_DISTRIB}"
+  echo "Installing package_cloud gem..."
+  gem install --no-document --user-install package_cloud
+  local gem_bin
+  gem_bin="$(ruby -e 'puts Gem.user_dir')/bin"
+  PATH="${gem_bin}:${PATH}"
+  export PATH
+}
 
-if [ "$REPO" = "" ]; then
-    echo "No REPO provided!"
+require_env() {
+  if [ -z "${REPO:-}" ]; then
+    echo "No REPO provided!" >&2
     exit 1
-elif [ "$SOURCE" = "" ]; then 
-    echo "No SOURCE provided!"
+  fi
+  if [ -z "${SOURCE:-}" ]; then
+    echo "No SOURCE provided!" >&2
     exit 1
-fi
+  fi
+  if [ -z "${PACKAGECLOUD_TOKEN:-}" ]; then
+    echo "No PACKAGECLOUD_TOKEN provided!" >&2
+    exit 1
+  fi
+}
 
 upload() {
-        echo "Uploading ${PACKAGE_NAME} to ${UPLOAD_PATH}."
-        package_cloud push ${UPLOAD_PATH} ${PACKAGE_NAME}
+  local upload_path="$1"
+  local package_name="$2"
+  echo "Uploading ${package_name} to ${upload_path}."
+  package_cloud push "${upload_path}" "${package_name}"
 }
 
 upload_file() {
-    if [ "$DISTRIBUTIONS" = "" ]; then
-        UPLOAD_PATH="${REPO}"
-        upload
-    else
-        for distrib in $DISTRIBUTIONS; do 
-            UPLOAD_PATH="${REPO}/${distrib}"
-            upload
-        done
-    fi
+  local repo="$1"
+  local package_name="$2"
+  local distributions="${3:-}"
+  if [ -z "${distributions}" ]; then
+    upload "${repo}" "${package_name}"
+    return
+  fi
+
+  local distrib
+  # Space-separated dist list is the documented Action input.
+  # shellcheck disable=SC2086
+  for distrib in $distributions; do
+    upload "${repo}/${distrib}" "${package_name}"
+  done
 }
 
 upload_folder() {
-    DISTRIBUTIONS="${PACKAGECLOUD_DEB_DISTRIB}"
-    for deb in ${SOURCE}/*.deb; do
-        PACKAGE_NAME=$deb
-        upload_file
-    done
+  local repo="$1"
+  local source="$2"
+  local deb_dists="${3:-}"
+  local rpm_dists="${4:-}"
+  local pkg found=0
 
-    DISTRIBUTIONS="${PACKAGECLOUD_RPM_DISTRIB}"
-    for rpm in ${SOURCE}/*.rpm; do
-        PACKAGE_NAME=$rpm
-        upload_file
-    done
+  for pkg in "${source}"/*.deb; do
+    found=1
+    upload_file "${repo}" "${pkg}" "${deb_dists}"
+  done
+  for pkg in "${source}"/*.rpm; do
+    found=1
+    upload_file "${repo}" "${pkg}" "${rpm_dists}"
+  done
+
+  if [ "${found}" -eq 0 ]; then
+    echo "No .deb or .rpm files in ${source}" >&2
+    exit 1
+  fi
 }
 
-if [ -d "$SOURCE" ]; then
-    upload_folder
-else 
-    if [ "${SOURCE##*.}" = "rpm" ]; then DISTRIBUTIONS="${PACKAGECLOUD_RPM_DISTRIB}"; fi
-    if [ "${SOURCE##*.}" = "deb" ]; then DISTRIBUTIONS="${PACKAGECLOUD_DEB_DISTRIB}"; fi
-    PACKAGE_NAME="${SOURCE}"
-    upload_file
+file_extension() {
+  local name="${1##*/}"
+  local ext="${name##*.}"
+  printf '%s' "${ext}" | tr '[:upper:]' '[:lower:]'
+}
+
+upload_single() {
+  local repo="$1"
+  local source="$2"
+  local rpm_dists="${3:-}"
+  local deb_dists="${4:-}"
+  if [ ! -f "${source}" ]; then
+    echo "SOURCE is not a file or directory: ${source}" >&2
+    exit 1
+  fi
+
+  local ext distributions=""
+  ext="$(file_extension "${source}")"
+  case "${ext}" in
+    rpm) distributions="${rpm_dists}" ;;
+    deb) distributions="${deb_dists}" ;;
+  esac
+  upload_file "${repo}" "${source}" "${distributions}"
+}
+
+main() {
+  require_env
+  echo "REPO=${REPO}"
+  echo "SOURCE=${SOURCE}"
+  echo "PACKAGECLOUD_RPM_DISTRIB=${PACKAGECLOUD_RPM_DISTRIB:-}"
+  echo "PACKAGECLOUD_DEB_DISTRIB=${PACKAGECLOUD_DEB_DISTRIB:-}"
+  install_cli
+  if [ -d "${SOURCE}" ]; then
+    upload_folder "${REPO}" "${SOURCE}" "${PACKAGECLOUD_DEB_DISTRIB:-}" "${PACKAGECLOUD_RPM_DISTRIB:-}"
+  else
+    upload_single "${REPO}" "${SOURCE}" "${PACKAGECLOUD_RPM_DISTRIB:-}" "${PACKAGECLOUD_DEB_DISTRIB:-}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
 fi


### PR DESCRIPTION
## Summary
- Rewrite `upload.sh` to drop `sudo gem install`, quote paths, and fail on missing token/file or empty package folders (deb-only folders still succeed).
- Add bats coverage for the upload matrix and a `test-and-lint` workflow (bats + shellcheck).
- Bump LICENSE to 2022-2026 and fix README typos; document that `@v1` / `@v1.N` float from a `vN.N.N` tag.

## Test plan
- [x] `shellcheck upload.sh`
- [x] `bats test` (10 cases)
- [x] CI `bats` and `shellcheck` jobs on this PR

Made with [Cursor](https://cursor.com)