### PR TITLE
Tighten bats spies and make release create idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,13 @@ jobs:
       - name: create-github-release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes
+        run: |
+          set -euo pipefail
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "release ${GITHUB_REF_NAME} already exists"
+          else
+            gh release create "${GITHUB_REF_NAME}" --generate-notes
+          fi
   # Plant/move the floating tags AFTER the release succeeds, and only when
   # this tag is the highest of its major/minor series so a backport cannot
   # regress uses: golift/upload-packagecloud@v1.

--- a/test/upload.bats
+++ b/test/upload.bats
@@ -1,28 +1,64 @@
 #!/usr/bin/env bats
 
+write_package_cloud_spy() {
+  cat > "$1" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'argc=%s\n' "$#"
+  printf '%s\n' "$@"
+  printf -- '---\n'
+} >> "${PACKAGECLOUD_LOG}"
+EOF
+  chmod +x "$1"
+}
+
+push_record() {
+  printf 'argc=%s\n' "$#"
+  printf '%s\n' "$@"
+  printf -- '---\n'
+}
+
 setup() {
   TEST_ROOT="${BATS_TEST_TMPDIR}"
   BIN="${TEST_ROOT}/bin"
   mkdir -p "${BIN}"
   export PACKAGECLOUD_LOG="${TEST_ROOT}/package_cloud.log"
   export GEM_LOG="${TEST_ROOT}/gem.log"
+  export SUDO_LOG="${TEST_ROOT}/sudo.log"
+  export GEM_USER_DIR="${TEST_ROOT}/gem-home"
   : > "${PACKAGECLOUD_LOG}"
   : > "${GEM_LOG}"
+  : > "${SUDO_LOG}"
 
-  cat > "${BIN}/package_cloud" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "${PACKAGECLOUD_LOG}"
-EOF
+  write_package_cloud_spy "${BIN}/package_cloud"
+
   cat > "${BIN}/gem" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${GEM_LOG}"
+if [ "${1-}" = install ]; then
+  mkdir -p "${GEM_USER_DIR}/bin"
+  cat > "${GEM_USER_DIR}/bin/package_cloud" <<'SPY'
+#!/usr/bin/env bash
+{
+  printf 'argc=%s\n' "$#"
+  printf '%s\n' "$@"
+  printf -- '---\n'
+} >> "${PACKAGECLOUD_LOG}"
+SPY
+  chmod +x "${GEM_USER_DIR}/bin/package_cloud"
+fi
 exit 0
+EOF
+  cat > "${BIN}/ruby" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${GEM_USER_DIR}"
 EOF
   cat > "${BIN}/sudo" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "${SUDO_LOG}"
 exec "$@"
 EOF
-  chmod +x "${BIN}/package_cloud" "${BIN}/gem" "${BIN}/sudo"
+  chmod +x "${BIN}/gem" "${BIN}/ruby" "${BIN}/sudo"
 
   export PATH="${BIN}:${PATH}"
   export REPO="golift/pkgs"
@@ -80,8 +116,11 @@ EOF
   export PACKAGECLOUD_RPM_DISTRIB="el/6"
   run "${SCRIPT}"
   [ "${status}" -eq 0 ]
-  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/ubuntu/focal ${TEST_ROOT}/pkgs/app.deb
-push golift/pkgs/debian/buster ${TEST_ROOT}/pkgs/app.deb" ]
+  expected="$(
+    push_record push "golift/pkgs/ubuntu/focal" "${TEST_ROOT}/pkgs/app.deb"
+    push_record push "golift/pkgs/debian/buster" "${TEST_ROOT}/pkgs/app.deb"
+  )"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
 }
 
 @test "folder with deb and rpm uploads both types" {
@@ -92,8 +131,11 @@ push golift/pkgs/debian/buster ${TEST_ROOT}/pkgs/app.deb" ]
   export PACKAGECLOUD_RPM_DISTRIB="el/6"
   run "${SCRIPT}"
   [ "${status}" -eq 0 ]
-  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/ubuntu/focal ${TEST_ROOT}/pkgs/app.deb
-push golift/pkgs/el/6 ${TEST_ROOT}/pkgs/app.rpm" ]
+  expected="$(
+    push_record push "golift/pkgs/ubuntu/focal" "${TEST_ROOT}/pkgs/app.deb"
+    push_record push "golift/pkgs/el/6" "${TEST_ROOT}/pkgs/app.rpm"
+  )"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
 }
 
 @test "single rpm with two rpmdists uploads twice" {
@@ -102,8 +144,11 @@ push golift/pkgs/el/6 ${TEST_ROOT}/pkgs/app.rpm" ]
   export PACKAGECLOUD_RPM_DISTRIB="el/6 el/7"
   run "${SCRIPT}"
   [ "${status}" -eq 0 ]
-  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs/el/6 ${SOURCE}
-push golift/pkgs/el/7 ${SOURCE}" ]
+  expected="$(
+    push_record push "golift/pkgs/el/6" "${SOURCE}"
+    push_record push "golift/pkgs/el/7" "${SOURCE}"
+  )"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
 }
 
 @test "non-rpm/deb file uploads to repo with no dist suffix" {
@@ -113,7 +158,19 @@ push golift/pkgs/el/7 ${SOURCE}" ]
   export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
   run "${SCRIPT}"
   [ "${status}" -eq 0 ]
-  [ "$(cat "${PACKAGECLOUD_LOG}")" = "push golift/pkgs ${SOURCE}" ]
+  expected="$(push_record push "golift/pkgs" "${SOURCE}")"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
+}
+
+@test "quoted paths with spaces stay a single argument" {
+  mkdir -p "${TEST_ROOT}/my pkgs"
+  touch "${TEST_ROOT}/my pkgs/app.deb"
+  export SOURCE="${TEST_ROOT}/my pkgs"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  expected="$(push_record push "golift/pkgs/ubuntu/focal" "${TEST_ROOT}/my pkgs/app.deb")"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
 }
 
 @test "skips gem install when package_cloud is on PATH" {
@@ -123,4 +180,17 @@ push golift/pkgs/el/7 ${SOURCE}" ]
   run "${SCRIPT}"
   [ "${status}" -eq 0 ]
   [ ! -s "${GEM_LOG}" ]
+}
+
+@test "installs package_cloud with gem --user-install when missing from PATH" {
+  rm -f "${BIN}/package_cloud"
+  export SOURCE="${TEST_ROOT}/pkg.deb"
+  touch "${SOURCE}"
+  export PACKAGECLOUD_DEB_DISTRIB="ubuntu/focal"
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${GEM_LOG}")" = "install --no-document --user-install package_cloud" ]
+  [ ! -s "${SUDO_LOG}" ]
+  expected="$(push_record push "golift/pkgs/ubuntu/focal" "${SOURCE}")"
+  [ "$(cat "${PACKAGECLOUD_LOG}")" = "${expected}" ]
 }


### PR DESCRIPTION
## Summary
- Record `package_cloud` argc and each argument separately, and add a fixture path with spaces so an unquoted `push` would fail the suite ([#4](https://github.com/golift/upload-packagecloud/pull/4)).
- Cover `gem install --user-install` when the CLI is missing from `PATH`, and assert `sudo` is not used.
- Skip `gh release create` when the release already exists so a workflow re-run can still move floating tags ([#5](https://github.com/golift/upload-packagecloud/pull/5)).

Left alone: the `v[0-9]+.[0-9]+.[0-9]+` tag filter. That pattern already fired for `v1.1.1`.

## Test plan
- [x] `bats test` (12 cases)
- [x] CI `bats` and `shellcheck` jobs on this PR

Made with [Cursor](https://cursor.com)